### PR TITLE
Switch from wget to curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,13 @@ URL_SIGN := $(URL).sig
 
 get-sources: $(SRC_FILE) $(SIGN_FILE)
 
+$(if $(FETCH_CMD),,$(error You cannot run this makefile without having $$(FETCH_CMD) set))
+
 $(SRC_FILE):
-	@wget -q -N $(URL)
+	@$(FETCH_CMD) $(SRC_FILE) $(URL)
 
 $(SIGN_FILE):
-	@wget -q -N $(URL_SIGN)
+	@$(FETCH_CMD) $(SIGN_FILE) $(URL_SIGN)
 
 import-keys:
 	@if [ -n "$$GNUPGHOME" ]; then rm -f "$$GNUPGHOME/linux-pvgrub2-trustedkeys.gpg"; fi

--- a/grub2-xen.spec
+++ b/grub2-xen.spec
@@ -20,8 +20,8 @@ Summary:        Bootloader with support for Linux, Multiboot and more, for Xen P
 
 Group:          System Environment/Base
 License:        GPLv3+
-URL:            http://www.gnu.org/software/grub/
-Source0:        http://ftp.gnu.org/gnu/grub/grub-%{tarversion}.tar.xz
+URL:            https://www.gnu.org/software/grub/
+Source0:        https://ftp.gnu.org/gnu/grub/grub-%{tarversion}.tar.xz
 Source1:        grub-bootstrap.cfg
 Source2:        grub-xen.cfg
 Patch0:         grub-alias-linux16.patch


### PR DESCRIPTION
curl has a better security track record than wget, and on Fedora uses a
better TLS library (OpenSSL instead of GnuTLS).  This change also adds
REPO_PROXY support.